### PR TITLE
Use strict mode

### DIFF
--- a/spider.js
+++ b/spider.js
@@ -1,3 +1,4 @@
+"use strict"
 const https = require('https');
 
 https.get( 'https://www.packtpub.com/packt/offers/free-learning', (res) => {


### PR DESCRIPTION
Without this it generates a syntax error.
 SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode 